### PR TITLE
blinks by changing the scale instead of SetActive

### DIFF
--- a/Assets/Scripts/BlinkGameObject.cs
+++ b/Assets/Scripts/BlinkGameObject.cs
@@ -16,7 +16,9 @@ public class BlinkGameObject : MonoBehaviour
 
     void StartBlinkGameObject()
     {
-        targetBlinkObject.SetActive(!targetBlinkObject.activeInHierarchy);
+        if(targetBlinkObject.transform.localScale == new Vector3(1, 1, 1)) {
+            targetBlinkObject.transform.localScale = new Vector3(0, 0, 0);
+        } else targetBlinkObject.transform.localScale = new Vector3(1, 1, 1);
     }
     public void StopBlinkGameObject()
     {


### PR DESCRIPTION
blinking the game object is happening by changing the local scale of it from 1 to 0 instead of using SetActive(false).